### PR TITLE
fix: handle zero cell values in workbook loader

### DIFF
--- a/util/loaders/Loader.ts
+++ b/util/loaders/Loader.ts
@@ -11,11 +11,11 @@ export abstract class Loader<T> {
 
   protected getCellValue(cellObj: CellObject | undefined) {
     if (!cellObj) return null;
-    if (cellObj.w) return cellObj.w;
+    if (cellObj.w !== undefined) return cellObj.w;
 
-    if (cellObj.v) return cellObj.v;
+    if (cellObj.v !== undefined) return cellObj.v;
 
-    if (cellObj.f) return cellObj.f;
+    if (cellObj.f !== undefined) return cellObj.f;
 
     return null;
   }


### PR DESCRIPTION
## Summary
- ensure loader returns 0-valued cells instead of null

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Error serializing `.soldiers[0].type` in "/soldiers" due to undefined value)*

------
https://chatgpt.com/codex/tasks/task_e_68993d90ed58832ea42dcd70d108e005