### PR TITLE
chore: modernize config for static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ Exclusives Name (CK)
 Exclusive Equipment image will also need to be updated.
 
 And as always check translations, and be aware sometimes zilong changes things last minuite.
+
+## Static hosting
+
+To publish the site on GitHub Pages, build the project as static files:
+
+```
+npm run export
+```
+
+The generated `out` directory can be served directly by GitHub Pages.

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,7 @@
 module.exports = {
+  trailingSlash: true,
   basePath: "",
   assetPrefix: "",
-  // future: {
-  //   webpack5: true,
-  // },
-  // target: "serverless",
   output: "export",
   // async headers() {
   //   return [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
-import { GetStaticProps } from "next";
-import { Layout } from "../components/Layout";
 import React from "react";
-import { DBSingleton, Patch, PatchMap } from "../util/databaseSingleton";
+import type { GetStaticProps } from "next";
+import { Layout } from "../components/Layout";
+import type { Patch, PatchMap } from "../util/databaseSingleton";
 import { PatchSection } from "../components/patch/PatchSection";
 import formatDate from "../util/formatDate.fn";
 import { Img } from "../components/layout/Img";
@@ -52,6 +52,7 @@ const Home = ({ patchMap }: { patchMap: PatchMap }) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
+  const { DBSingleton } = await import("../util/databaseSingleton");
   const patchMap = DBSingleton.getInstance().getPatchMap();
 
   return {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,17 +1,16 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
-  purge: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
-  darkMode: false, // or 'media' or 'class'
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     extend: {
       fontFamily: {
         sans: ["Loto", ...defaultTheme.fontFamily.sans],
       },
     },
-  },
-  variants: {
-    extend: {},
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- use type-only imports and dynamic loading on home page
- add trailingSlash for GitHub Pages exports
- update Tailwind config to content API
- document static export workflow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68993f9a0dc4832e8cfb00c3ee7650ec