### PR TITLE
Configure GitHub Pages base path and update data source link

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,3 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./out
-          cname: wikigrisser-next.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Wikigrisser Open source Project
 
-https://docs.google.com/spreadsheets/d/12anuYkAchUiGXs26-fHl16vDMbTXt99XrFbZE11sh3o/edit?usp=sharing
+https://docs.google.com/spreadsheets/d/13vk5WD23k2DQjdglmBUdlg6a6cR3ulCiWQoZ2eq7X-Q/edit?usp=sharing
 
 Updating when global release comes out:
 When a units global release comes out some changes will need to be made in the google sheets to reflect the now official names of units, classes and skills

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  basePath: "",
-  assetPrefix: "",
+  basePath: "/wikigrisser-next",
+  assetPrefix: "/wikigrisser-next/",
   // future: {
   //   webpack5: true,
   // },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev-windows": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next build && next export"
+    "export": "node scripts/fetch-database.js && next build && next export"
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",

--- a/scripts/fetch-database.js
+++ b/scripts/fetch-database.js
@@ -1,0 +1,19 @@
+const https = require('https');
+const fs = require('fs');
+
+const url = 'https://docs.google.com/spreadsheets/d/13vk5WD23k2DQjdglmBUdlg6a6cR3ulCiWQoZ2eq7X-Q/export?format=xlsx';
+
+https.get(url, (res) => {
+  if (res.statusCode !== 200) {
+    console.error('Failed to download database:', res.statusCode);
+    res.resume();
+    return;
+  }
+  const data = [];
+  res.on('data', (chunk) => data.push(chunk));
+  res.on('end', () => {
+    fs.writeFileSync('data/database.xlsx', Buffer.concat(data));
+  });
+}).on('error', (err) => {
+  console.error('Failed to download database', err);
+});


### PR DESCRIPTION
## Summary
- set Next.js basePath and assetPrefix for GitHub Pages deployment
- update data source to new Google Sheets link with fetch script
- remove custom domain from GitHub Pages workflow

## Testing
- `npm install`
- `npm run export` *(fails to download Google Sheet: ENETUNREACH, but build completes with existing data)*

------
https://chatgpt.com/codex/tasks/task_e_689941f8e7e4832e8bd617ab789f5d1a